### PR TITLE
Force user to type sql keywords in lower case

### DIFF
--- a/app/etl/controllers.py
+++ b/app/etl/controllers.py
@@ -11,7 +11,6 @@ from tabulate import tabulate
 def compile():
     try:
         query = str(ui.inputbox.text())
-        query = query.lower()
         result = parser.parse(query)
         ui.outputbox.setText(str(result))
     except Exception as e:


### PR DESCRIPTION
Forced the user to use keywords in lower case and keeping the rest of the input untouched like making them lower or upper case